### PR TITLE
feat: Expose the container image builder type in the dev console

### DIFF
--- a/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
+++ b/extensions/container-image/container-image-docker/deployment/src/main/java/io/quarkus/container/image/docker/deployment/DockerProcessor.java
@@ -24,6 +24,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
+import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImagePushRequestBuildItem;
@@ -43,14 +44,19 @@ import io.quarkus.deployment.util.ExecUtil;
 public class DockerProcessor {
 
     private static final Logger log = Logger.getLogger(DockerProcessor.class);
+    private static final String DOCKER = "docker";
     private static final String DOCKERFILE_JVM = "Dockerfile.jvm";
     private static final String DOCKERFILE_FAST_JAR = "Dockerfile.fast-jar";
     private static final String DOCKERFILE_NATIVE = "Dockerfile.native";
     private static final String DOCKER_DIRECTORY_NAME = "docker";
-
     static final String DOCKER_CONTAINER_IMAGE_NAME = "docker";
 
     private final DockerWorking dockerWorking = new DockerWorking();
+
+    @BuildStep
+    public AvailableContainerImageExtensionBuildItem availability() {
+        return new AvailableContainerImageExtensionBuildItem(DOCKER);
+    }
 
     @BuildStep(onlyIf = DockerBuild.class)
     public CapabilityBuildItem capability() {

--- a/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
+++ b/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java
@@ -39,6 +39,7 @@ import io.quarkus.bootstrap.util.ZipUtils;
 import io.quarkus.builder.Version;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.NativeBinaryUtil;
+import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageLabelBuildItem;
@@ -65,6 +66,11 @@ public class JibProcessor {
     public static final String JIB = "jib";
     private static final IsClassPredicate IS_CLASS_PREDICATE = new IsClassPredicate();
     private static final String BINARY_NAME_IN_CONTAINER = "application";
+
+    @BuildStep
+    public AvailableContainerImageExtensionBuildItem availability() {
+        return new AvailableContainerImageExtensionBuildItem(JIB);
+    }
 
     @BuildStep(onlyIf = JibBuild.class)
     public CapabilityBuildItem capability() {

--- a/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
+++ b/extensions/container-image/container-image-openshift/deployment/src/main/java/io/quarkus/container/image/openshift/deployment/OpenshiftProcessor.java
@@ -46,6 +46,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.ImageUtil;
+import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.container.spi.BaseImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
@@ -77,6 +78,11 @@ public class OpenshiftProcessor {
     private static final String RUNNING = "Running";
 
     private static final Logger LOG = Logger.getLogger(OpenshiftProcessor.class);
+
+    @BuildStep
+    public AvailableContainerImageExtensionBuildItem availability() {
+        return new AvailableContainerImageExtensionBuildItem(OPENSHIFT);
+    }
 
     @BuildStep(onlyIf = OpenshiftBuild.class)
     public CapabilityBuildItem capability() {

--- a/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
+++ b/extensions/container-image/container-image-s2i/deployment/src/main/java/io/quarkus/container/image/s2i/deployment/S2iProcessor.java
@@ -42,6 +42,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.quarkus.bootstrap.model.AppDependency;
 import io.quarkus.container.image.deployment.ContainerImageConfig;
 import io.quarkus.container.image.deployment.util.ImageUtil;
+import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.container.spi.BaseImageInfoBuildItem;
 import io.quarkus.container.spi.ContainerImageBuildRequestBuildItem;
 import io.quarkus.container.spi.ContainerImageInfoBuildItem;
@@ -73,6 +74,11 @@ public class S2iProcessor {
     private static final String RUNNING = "Running";
 
     private static final Logger LOG = Logger.getLogger(S2iProcessor.class);
+
+    @BuildStep
+    public AvailableContainerImageExtensionBuildItem availability() {
+        return new AvailableContainerImageExtensionBuildItem(S2I);
+    }
 
     @BuildStep(onlyIf = S2iBuild.class)
     public CapabilityBuildItem capability() {

--- a/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devconsole/ContainerImageDevConsoleProcessor.java
+++ b/extensions/container-image/deployment/src/main/java/io/quarkus/container/image/deployment/devconsole/ContainerImageDevConsoleProcessor.java
@@ -1,9 +1,13 @@
 package io.quarkus.container.image.deployment.devconsole;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import io.quarkus.container.spi.AvailableContainerImageExtensionBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
+import io.quarkus.devconsole.spi.DevConsoleTemplateInfoBuildItem;
 
 public class ContainerImageDevConsoleProcessor {
 
@@ -11,5 +15,28 @@ public class ContainerImageDevConsoleProcessor {
     DevConsoleRouteBuildItem builder() {
         return new DevConsoleRouteBuildItem("build", "POST",
                 new RebuildHandler(Collections.singletonMap("quarkus.container-image.build", "true")));
+    }
+
+    @BuildStep
+    DevConsoleTemplateInfoBuildItem handleGetBuilders(List<AvailableContainerImageExtensionBuildItem> extensions) {
+        return new DevConsoleTemplateInfoBuildItem("builder",
+                extensions.stream().map(s -> new BuilderType(s.getName())).collect(Collectors.toList()));
+    }
+
+    public static class BuilderType implements Comparable<BuilderType> {
+        private final String name;
+
+        public BuilderType(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        @Override
+        public int compareTo(BuilderType o) {
+            return name.compareTo(o.name);
+        }
     }
 }

--- a/extensions/container-image/deployment/src/main/resources/dev-templates/build.html
+++ b/extensions/container-image/deployment/src/main/resources/dev-templates/build.html
@@ -16,6 +16,14 @@ color: gray;
         <option value="fast-jar">Fast Jar</option>
         <option value="native">Native</option>
     </select>
+
+    Builder Type:
+    <select name="quarkus.container-image.builder" required="false">
+    {#for item in info:builder}
+        <option value="{item.name}">{item.name}</option>
+    {/for}
+    </select>
+ 
     <input type="submit" value="Build" >
 </form>
 {/body}

--- a/extensions/container-image/spi/src/main/java/io/quarkus/container/spi/AvailableContainerImageExtensionBuildItem.java
+++ b/extensions/container-image/spi/src/main/java/io/quarkus/container/spi/AvailableContainerImageExtensionBuildItem.java
@@ -1,0 +1,18 @@
+
+package io.quarkus.container.spi;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class AvailableContainerImageExtensionBuildItem extends MultiBuildItem {
+
+    private final String name;
+
+    public AvailableContainerImageExtensionBuildItem(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+}


### PR DESCRIPTION
This pull request enhances the `container image build` operation by exposing the builder type:
- openshift
- s2i
- docker 
- jib

Currently, only one of the above may be enabled at a time (through the option `quarkus.container-image.builder`). The pull request allows you to choose a different builder if available.